### PR TITLE
Fix warning for implicit declaration of function msgUpdateCallback (2nd attempt)

### DIFF
--- a/csp/msg.go
+++ b/csp/msg.go
@@ -3,7 +3,11 @@ package csp
 /*
 #include "common.h"
 
-extern PFN_CMSG_STREAM_OUTPUT msgUpdateCallback;
+extern BOOL WINAPI msgUpdateCallback(
+    const void *pvArg,
+    BYTE *pbData,
+    DWORD cbData,
+    BOOL fFinal);
 
 static BOOL WINAPI msgUpdateCallback_cgo(
     const void *pvArg,


### PR DESCRIPTION
The previous fix resulted in segfault.