### PR TITLE
#5: macOS build fix

### DIFF
--- a/csp/common.go
+++ b/csp/common.go
@@ -3,7 +3,8 @@
 package csp
 
 /*
-#cgo linux CFLAGS: -I/opt/cprocsp/include/cpcsp
+#cgo linux,amd64,386 darwin CFLAGS: -I/opt/cprocsp/include/cpcsp
+#cgo 386 darwin LDFLAGS: -L/opt/cprocsp/lib -lcapi10 -lcapi20 -lrdrsup -lssp
 #cgo linux,amd64 LDFLAGS: -L/opt/cprocsp/lib/amd64/ -lcapi10 -lcapi20 -lrdrsup -lssp
 #cgo linux,386 LDFLAGS: -L/opt/cprocsp/lib/ia32/ -lcapi10 -lcapi20 -lrdrsup -lssp
 #cgo windows LDFLAGS: -lcrypt32 -lpthread


### PR DESCRIPTION
Добавление возможности билда под macOS.
Предварительно, конечно же, необходимо установить CryptoPro CSP.